### PR TITLE
feat: make media stack ports and paths configurable

### DIFF
--- a/media/README.md
+++ b/media/README.md
@@ -19,8 +19,14 @@ docker compose -f media-server.yaml up -d
 ```
 
 ## 环境变量
-可以通过环境变量自定义端口：
+可以通过环境变量自定义端口和目录：
+- `MEDIA_STACK_ROOT` - 持久化数据根目录 (默认: `/data/apps`)
+- `MEDIA_DOWNLOADS_DIR` - 下载内容共享目录 (默认: `${MEDIA_STACK_ROOT}/qbittorrent/downloads`)
+
+端口：
 - `QBIT_PORT_UI` - qBittorrent Web UI 端口 (默认: 8080)
+- `QBIT_PORT_CONN` - qBittorrent TCP/UDP 连接端口 (默认: 6881)
 - `MOVIEPILOT_PORT` - MoviePilot 端口 (默认: 3000)
 - `JELLYFIN_PORT_HTTP` - Jellyfin HTTP 端口 (默认: 8096)
 - `JELLYSEERR_PORT` - Jellyseerr 端口 (默认: 5055)
+

--- a/media/compose/media-server.yaml
+++ b/media/compose/media-server.yaml
@@ -20,11 +20,11 @@ services:
       - "${MEDIA_STACK_ROOT:-/data/apps}/jellyfin/config:/config"
       - "${MEDIA_STACK_ROOT:-/data/apps}/jellyfin/cache:/cache"
       - "${MEDIA_STACK_ROOT:-/data/apps}/jellyfin/logs:/logs"
-      - "${MEDIA_STACK_ROOT:-/data/apps}/jellyfin/media:/media:ro"
+      - "${MEDIA_DOWNLOADS_DIR:-${MEDIA_STACK_ROOT:-/data/apps}/qbittorrent/downloads}:/media:ro"
     ports:
       - "${JELLYFIN_PORT_HTTP:-8096}:8096"
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://localhost:8096/health"]
+      test: ["CMD", "curl", "-fsS", "http://localhost:${JELLYFIN_PORT_HTTP:-8096}/health"]
       interval: 30s
       timeout: 5s
       retries: 10
@@ -41,7 +41,7 @@ services:
     ports:
       - "${JELLYSEERR_PORT:-5055}:5055"
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://localhost:5055/api/v1/status"]
+      test: ["CMD", "curl", "-fsS", "http://localhost:${JELLYSEERR_PORT:-5055}/api/v1/status"]
       interval: 30s
       timeout: 5s
       retries: 10

--- a/media/compose/moviepilot.yaml
+++ b/media/compose/moviepilot.yaml
@@ -19,7 +19,7 @@ services:
     volumes:
       - "${MEDIA_STACK_ROOT:-/data/apps}/moviepilot/config:/config"
       - "${MEDIA_STACK_ROOT:-/data/apps}/moviepilot/data:/data"
-      - "${MEDIA_STACK_ROOT:-/data/apps}/qbittorrent/downloads:/downloads:rw"
+      - "${MEDIA_DOWNLOADS_DIR:-${MEDIA_STACK_ROOT:-/data/apps}/qbittorrent/downloads}:/downloads:rw"
       - "${MEDIA_STACK_ROOT:-/data/apps}/moviepilot/logs:/logs"
     ports:
       - "${MOVIEPILOT_PORT:-3000}:3000"

--- a/media/compose/qbittorrent.yaml
+++ b/media/compose/qbittorrent.yaml
@@ -18,17 +18,18 @@ services:
     environment:
       <<: *common-env
       WEBUI_PORT: "${QBIT_PORT_UI:-8080}"
+      TORRENTING_PORT: "${QBIT_PORT_CONN:-6881}"
     volumes:
       - "${MEDIA_STACK_ROOT:-/data/apps}/qbittorrent/config:/config"
-      - "${MEDIA_STACK_ROOT:-/data/apps}/qbittorrent/downloads:/downloads"
+      - "${MEDIA_DOWNLOADS_DIR:-${MEDIA_STACK_ROOT:-/data/apps}/qbittorrent/downloads}:/downloads"
       - "${MEDIA_STACK_ROOT:-/data/apps}/qbittorrent/watch:/watch"
       - "${MEDIA_STACK_ROOT:-/data/apps}/qbittorrent/logs:/logs"
     ports:
-      - "${QBIT_PORT_UI:-8080}:8080"
-      - "6881:6881"
-      - "6881:6881/udp"
+      - "${QBIT_PORT_UI:-8080}:${QBIT_PORT_UI:-8080}"
+      - "${QBIT_PORT_CONN:-6881}:${QBIT_PORT_CONN:-6881}"
+      - "${QBIT_PORT_CONN:-6881}:${QBIT_PORT_CONN:-6881}/udp"
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://localhost:8080"]
+      test: ["CMD", "curl", "-fsS", "http://localhost:${QBIT_PORT_UI:-8080}"]
       interval: 30s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary
- allow configuring qbittorrent torrenting port and shared downloads path
- expose shared downloads directory to moviepilot and jellyfin
- document ports and path variables for media stack

## Testing
- `yamllint -d '{extends: default, rules: {document-start: disable, colons: disable, braces: disable, line-length: {max: 120}}}' media/compose/qbittorrent.yaml media/compose/moviepilot.yaml media/compose/media-server.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68baf5856148832d92f71011a09ec1a4