### PR TITLE
feat(moviepilot): add v2 stack with postgres and redis

### DIFF
--- a/media/README.md
+++ b/media/README.md
@@ -2,7 +2,7 @@
 
 包含服务：
 - qBittorrent (下载器) - 端口 8080
-- MoviePilot (下载编排) - 端口 3000
+- MoviePilot v2 (下载编排，附 PostgreSQL/Redis) - 端口 3000
 - Jellyfin (媒体服务器) - 端口 8096
 - Jellyseerr (点播/请求管理) - 端口 5055
 
@@ -26,6 +26,7 @@ docker compose -f compose/media-server.yaml up -d
 - `QBIT_PORT_UI` - qBittorrent Web UI 端口 (默认: 8080)
 - `QBIT_PORT_CONN` - qBittorrent TCP/UDP 连接端口 (默认: 6881)
 - `MOVIEPILOT_PORT` - MoviePilot 端口 (默认: 3000)
+- `MOVIEPILOT_API_PORT` - MoviePilot API 端口 (默认: 3001)
 - `JELLYFIN_PORT_HTTP` - Jellyfin HTTP 端口 (默认: 8096)
 - `JELLYSEERR_PORT` - Jellyseerr 端口 (默认: 5055)
 

--- a/media/compose/moviepilot.yaml
+++ b/media/compose/moviepilot.yaml
@@ -13,19 +13,62 @@ x-logging: &logging
 
 services:
   moviepilot:
-    image: jxxghp/moviepilot:latest
-    container_name: moviepilot
-    environment: *common-env
+    image: jxxghp/moviepilot-v2:latest
+    container_name: moviepilot-v2
+    hostname: moviepilot-v2
+    environment:
+      <<: *common-env
+      NGINX_PORT: "3000"
+      PORT: "3001"
+      SUPERUSER: "${MOVIEPILOT_SUPERUSER:-admin}"
+      DB_TYPE: postgresql
+      DB_POSTGRESQL_HOST: postgresql
+      DB_POSTGRESQL_PORT: 5432
+      DB_POSTGRESQL_DATABASE: moviepilot
+      DB_POSTGRESQL_USERNAME: moviepilot
+      DB_POSTGRESQL_PASSWORD: "${MOVIEPILOT_DB_PASSWORD:-pg_password}"
+      CACHE_BACKEND_TYPE: redis
+      CACHE_BACKEND_URL: "redis://:${MOVIEPILOT_REDIS_PASSWORD:-redis_password}@redis:6379"
     volumes:
       - "${MEDIA_STACK_ROOT:-/data/apps}/moviepilot/config:/config"
-      - "${MEDIA_STACK_ROOT:-/data/apps}/moviepilot/data:/data"
-      - "${MEDIA_DOWNLOADS_DIR:-${MEDIA_STACK_ROOT:-/data/apps}/qbittorrent/downloads}:/downloads:rw"
-      - "${MEDIA_STACK_ROOT:-/data/apps}/moviepilot/logs:/logs"
+      - "${MEDIA_STACK_ROOT:-/data/apps}/moviepilot/cache:/moviepilot/.cache/ms-playwright"
+      - "${MEDIA_DOWNLOADS_DIR:-/data/apps/qbittorrent/downloads}:/downloads"
+      - "${MEDIA_STACK_ROOT:-/data/apps}/qbittorrent/config/qBittorrent/data/BT_backup:/BT_backup"
+      - "${MEDIA_STACK_ROOT:-/data/apps}/transmission/config/torrents:/torrents"
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
     ports:
       - "${MOVIEPILOT_PORT:-3000}:3000"
+      - "${MOVIEPILOT_API_PORT:-3001}:3001"
+    depends_on:
+      postgresql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    <<: [*restart, *logging]
+
+  redis:
+    image: redis:alpine
+    command: redis-server --save 600 1 --requirepass ${MOVIEPILOT_REDIS_PASSWORD:-redis_password}
+    volumes:
+      - "${MEDIA_STACK_ROOT:-/data/apps}/moviepilot/redis:/data"
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://localhost:3000"]
-      interval: 30s
+      test: ["CMD", "redis-cli", "--raw", "incr", "ping"]
+      interval: 10s
       timeout: 5s
-      retries: 10
+      retries: 5
+    <<: [*restart, *logging]
+
+  postgresql:
+    image: postgres:alpine
+    environment:
+      POSTGRES_DB: moviepilot
+      POSTGRES_USER: moviepilot
+      POSTGRES_PASSWORD: "${MOVIEPILOT_DB_PASSWORD:-pg_password}"
+    volumes:
+      - "${MEDIA_STACK_ROOT:-/data/apps}/moviepilot/postgresql:/var/lib/postgresql/data"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U moviepilot -d moviepilot"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     <<: [*restart, *logging]


### PR DESCRIPTION
## Summary
- update MoviePilot stack to v2 with integrated PostgreSQL and Redis
- document new MoviePilot ports

## Testing
- `docker-compose -f media/compose/moviepilot.yaml config`

------
https://chatgpt.com/codex/tasks/task_e_68bb062ee3b0832daacca57691fe026d